### PR TITLE
Added alternative keymap using tab to autocomplete

### DIFF
--- a/Tabs.sublime-keymap
+++ b/Tabs.sublime-keymap
@@ -1,0 +1,32 @@
+[
+  { 
+    "keys": ["tab"],
+    "command": "alternative_autocomplete",
+    "args": {"default": "\t"},
+    "context": [
+      { "key": "num_selections", "operator": "equal", "operand": 1 }
+    ]
+  },
+  {
+    "keys": ["shift+tab"],
+    "command": "alternative_autocomplete",
+    "args": {"cycle": "previous"},
+    "context": [
+      { "key": "num_selections", "operator": "equal", "operand": 1 }
+    ]
+  },
+  { 
+    "keys": ["tab"],
+    "command": "indent",
+    "context": [
+      { "key": "text", "operator": "regex_contains", "operand": "\n" }
+    ]
+  },
+  { 
+    "keys": ["shift+tab"],
+    "command": "unindent",
+    "context": [
+      { "key": "text", "operator": "regex_contains", "operand": "\n" }
+    ]
+  }
+]


### PR DESCRIPTION
I noticed the last commit references a Tabs.sublime-keymap file to use the tab key for autocompletion, but the file doesn't appear to be included in the repo.  I created the file with settings described in previous versions of the readme.
